### PR TITLE
Homebrew Formulea for apim-3.1.0 - syntax errors

### DIFF
--- a/Formula/wso2am-3.1.0.rb
+++ b/Formula/wso2am-3.1.0.rb
@@ -2,8 +2,7 @@
 # Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 # -------------------------------------------------------------------------
 
-class Wso2amAnalytics310 < Formula
-  class Wso2am310 < Formula
+class Wso2am310 < Formula
     desc "WSO2 API Manager 3.1.0"
     homepage "https://wso2.com/api-management/"
     url "https://dl.bintray.com/wso2/binary/wso2am-3.1.0.zip"


### PR DESCRIPTION
## Purpose
> Correct syntax errors in Homebrew Formulea